### PR TITLE
Ensure token requests include created_at_apid or updated_at_apid as a…

### DIFF
--- a/apigee_sync.go
+++ b/apigee_sync.go
@@ -255,8 +255,13 @@ func getBearerToken() {
 		req.Header.Set("apid_instance_id", apidInfo.InstanceID)
 		req.Header.Set("apid_cluster_Id", apidInfo.ClusterID)
 		req.Header.Set("status", "ONLINE")
-		req.Header.Set("created_at_apid", time.Now().Format(time.RFC3339))
 		req.Header.Set("plugin_details", apidPluginDetails)
+
+		if apidInfo.InstanceID == "" {
+			req.Header.Set("created_at_apid", time.Now().Format(time.RFC3339))
+		} else {
+			req.Header.Set("updated_at_apid", time.Now().Format(time.RFC3339))
+		}
 
 		client := &http.Client{}
 		resp, err := client.Do(req)

--- a/mock_server.go
+++ b/mock_server.go
@@ -240,6 +240,14 @@ func (m *MockServer) sendToken(w http.ResponseWriter, req *http.Request) {
 	Expect(req.Header.Get("apid_cluster_Id")).To(Equal(m.params.ClusterID))
 	Expect(req.Header.Get("display_name")).ToNot(BeEmpty())
 
+	if req.Header.Get("apid_instance_id") == "" {
+		Expect(req.Header.Get("created_at_apid")).ToNot(BeEmpty())
+		Expect(req.Header.Get("updated_at_apid")).To(BeEmpty())
+	} else {
+		Expect(req.Header.Get("created_at_apid")).To(BeEmpty())
+		Expect(req.Header.Get("updated_at_apid")).ToNot(BeEmpty())
+	}
+
 	Expect(req.Form.Get("client_id")).To(Equal(m.params.TokenKey))
 	Expect(req.Form.Get("client_secret")).To(Equal(m.params.TokenSecret))
 


### PR DESCRIPTION
…ppropriate