### PR TITLE
Set column values to "", otherwise they default to NULL, which needs

### DIFF
--- a/data.go
+++ b/data.go
@@ -254,7 +254,8 @@ func getApidInstanceInfo() (info apidInstanceInfo, err error) {
 			newInstanceID = true
 			info.InstanceID = generateUUID()
 
-			db.Exec("INSERT INTO APID (instance_id) VALUES (?)", info.InstanceID)
+			db.Exec("INSERT INTO APID (instance_id, last_snapshot_info) VALUES (?,?)",
+				info.InstanceID, "")
 		}
 	}
 	return

--- a/init_test.go
+++ b/init_test.go
@@ -18,8 +18,9 @@ var _ = Describe("init", func() {
 			config.Set(configName, "aa01")
 			initDefaults()
 			var apidInfoLatest apidInstanceInfo
-			apidInfoLatest , _ = getApidInstanceInfo()
+			apidInfoLatest, _ = getApidInstanceInfo()
 			Expect(apidInfoLatest.InstanceName).To(Equal("aa01"))
+			Expect(apidInfoLatest.LastSnapshot).To(Equal(""))
 		})
 
 	})


### PR DESCRIPTION
Currently when apid is started with bad credential, it INSERTS into apid, but snapshot_info is not set. This defaults to NULL. Subsequently when restarted, QueryRow() fails as last_snapshot_info is NULL, and apid is stopped prematurely. By setting it as "", the row is queryable. The apidInfo.LastSnapshot is already look for "".