### PR TITLE
feature: detect new DDL and replicate it by forcing a new snapshot

### DIFF
--- a/apigeeSync_suite_test.go
+++ b/apigeeSync_suite_test.go
@@ -64,10 +64,32 @@ var _ = BeforeSuite(func(done Done) {
 	// This is actually the first test :)
 	// Tests that entire bootstrap and set of sync operations work
 	var lastSnapshot *common.Snapshot
+
+	expectedSnapshotTables := make(map[string] bool)
+	expectedSnapshotTables["kms.company"] = true
+	expectedSnapshotTables["edgex.apid_cluster"] = true
+	expectedSnapshotTables["edgex.data_scope"] = true
+
 	apid.Events().ListenFunc(ApigeeSyncEventSelector, func(event apid.Event) {
 		defer GinkgoRecover()
 
 		if s, ok := event.(*common.Snapshot); ok {
+
+			//verify that during downloadDataSnapshot, knownTables was correctly populated
+			Expect(mapIsSubset(knownTables, expectedSnapshotTables)).To(BeTrue())
+
+			/* After this, we will mock changes for tables not present in the initial snapshot
+ 			* until that is changed in the mock server, we have to spoof the known tables
+			*/
+
+			//add apid_cluster and data_scope since those would present if this were a real scenario
+			knownTables["kms.app_credential"] = true
+			knownTables["kms.app_credential_apiproduct_mapper"] = true
+			knownTables["kms.developer"] = true
+			knownTables["kms.company_developer"] = true
+			knownTables["kms.api_product"] = true
+			knownTables["kms.app"] = true
+
 
 			lastSnapshot = s
 

--- a/apigee_sync_test.go
+++ b/apigee_sync_test.go
@@ -11,12 +11,22 @@ var _ = Describe("listener", func() {
 
 	It("should bootstrap from local DB if present", func(done Done) {
 
+		expectedTables := make(map[string] bool)
+		expectedTables["kms.company"] = true
+		expectedTables["edgex.apid_cluster"] = true
+		expectedTables["edgex.data_scope"] = true
+
+
 		Expect(apidInfo.LastSnapshot).NotTo(BeEmpty())
 
 		apid.Events().ListenFunc(ApigeeSyncEventSelector, func(event apid.Event) {
 			defer GinkgoRecover()
 
 			if s, ok := event.(*common.Snapshot); ok {
+
+				//verify that the knownTables array has been properly populated from existing DB
+				Expect(mapIsSubset(knownTables, expectedTables)).To(BeTrue())
+
 				Expect(s.SnapshotInfo).Should(Equal(apidInfo.LastSnapshot))
 				Expect(s.Tables).To(BeNil())
 

--- a/apigee_sync_test.go
+++ b/apigee_sync_test.go
@@ -16,7 +16,6 @@ var _ = Describe("listener", func() {
 		expectedTables["edgex.apid_cluster"] = true
 		expectedTables["edgex.data_scope"] = true
 
-
 		Expect(apidInfo.LastSnapshot).NotTo(BeEmpty())
 
 		apid.Events().ListenFunc(ApigeeSyncEventSelector, func(event apid.Event) {
@@ -35,6 +34,27 @@ var _ = Describe("listener", func() {
 		})
 
 		bootstrap()
+	})
+
+	It("should correctly identify non-proper subsets with respect to maps", func() {
+
+		//test b proper subset of a
+		Expect(mapIsSubset(map[string]bool{"a": true, "b": true}, map[string]bool{"b": true})).To(BeTrue())
+
+		//test a == b
+		Expect(mapIsSubset(map[string]bool{"a": true, "b": true}, map[string]bool{"a": true, "b": true})).To(BeTrue())
+
+		//test b superset of a
+		Expect(mapIsSubset(map[string]bool{"a": true, "b": true}, map[string]bool{"a": true, "b": true, "c": true})).To(BeFalse())
+
+		//test b not subset of a
+		Expect(mapIsSubset(map[string]bool{"a": true, "b": true}, map[string]bool{"c": true})).To(BeFalse())
+
+		//test b empty
+		Expect(mapIsSubset(map[string]bool{"a": true, "b": true}, map[string]bool{})).To(BeTrue())
+
+		//test a empty
+		Expect(mapIsSubset(map[string]bool{}, map[string]bool{"b": true})).To(BeFalse())
 	})
 
 	// todo: disabled for now -

--- a/listener_test.go
+++ b/listener_test.go
@@ -10,10 +10,14 @@ import (
 var _ = Describe("listener", func() {
 
 	handler := handler{}
+	var saveLastSnapshot string
 
 	Context("ApigeeSync snapshot event", func() {
 
 		It("should set DB to appropriate version", func() {
+
+			//save the last snapshot, so we can restore it at the end of this context
+			saveLastSnapshot = apidInfo.LastSnapshot
 
 			event := common.Snapshot{
 				SnapshotInfo: "test_snapshot",
@@ -152,6 +156,9 @@ var _ = Describe("listener", func() {
 			Expect(ds.CreatedBy).To(Equal("c"))
 			Expect(ds.Updated).To(Equal("u"))
 			Expect(ds.UpdatedBy).To(Equal("u"))
+
+			//restore the last snapshot
+			apidInfo.LastSnapshot = saveLastSnapshot
 		})
 	})
 
@@ -160,6 +167,9 @@ var _ = Describe("listener", func() {
 		Context(LISTENER_TABLE_APID_CLUSTER, func() {
 
 			It("insert event should panic", func() {
+				//save the last snapshot, so we can restore it at the end of this context
+				saveLastSnapshot = apidInfo.LastSnapshot
+
 
 				event := common.ChangeList{
 					LastSequence: "test",
@@ -187,6 +197,8 @@ var _ = Describe("listener", func() {
 				}
 
 				Expect(func() { handler.Handle(&event) }).To(Panic())
+				//restore the last snapshot
+				apidInfo.LastSnapshot = saveLastSnapshot
 			})
 
 			PIt("delete event should kill all the things!")
@@ -195,6 +207,10 @@ var _ = Describe("listener", func() {
 		Context(LISTENER_TABLE_DATA_SCOPE, func() {
 
 			It("insert event should add", func() {
+				//save the last snapshot, so we can restore it at the end of this context
+				saveLastSnapshot = apidInfo.LastSnapshot
+
+
 				event := common.ChangeList{
 					LastSequence: "test",
 					Changes: []common.Change{
@@ -306,7 +322,11 @@ var _ = Describe("listener", func() {
 				}
 
 				Expect(func() { handler.Handle(&event) }).To(Panic())
+				//restore the last snapshot
+				apidInfo.LastSnapshot = saveLastSnapshot
 			})
+
+
 
 		})
 

--- a/mock_server.go
+++ b/mock_server.go
@@ -311,7 +311,7 @@ func (m *MockServer) sendChanges(w http.ResponseWriter, req *http.Request) {
 	val := atomic.SwapInt32(m.newSnap, 0)
 	if val > 0 {
 		w.WriteHeader(http.StatusBadRequest)
-		apiErr := apiError{
+		apiErr := changeServerError{
 			Code: "SNAPSHOT_TOO_OLD",
 		}
 		bytes, err := json.Marshal(apiErr)


### PR DESCRIPTION
keep a list of known tables
persist these known tables to db if starting from existing db
identify and new tables that come in via changelist, update snapshot if so