### PR TITLE
Ensure datascopes don't pick redundant scopes.

### DIFF
--- a/data.go
+++ b/data.go
@@ -165,8 +165,8 @@ func deleteDataScope(ds dataDataScope, txn *sql.Tx) error {
 }
 
 /*
- * For the given apidConfigId, this function will retrieve all the scopes
- * associated with it
+ * For the given apidConfigId, this function will retrieve all the distinch scopes
+ * associated with it. Distinct, because scope is already a collection of the tenants.
  */
 func findScopesForId(configId string) (scopes []string) {
 
@@ -175,7 +175,7 @@ func findScopesForId(configId string) (scopes []string) {
 	var scope string
 	db := getDB()
 
-	rows, err := db.Query("select scope from DATA_SCOPE where apid_cluster_id = $1", configId)
+	rows, err := db.Query("select DISTINCT scope from DATA_SCOPE where apid_cluster_id = $1", configId)
 	if err != nil {
 		log.Errorf("Failed to query DATA_SCOPE: %v", err)
 		return

--- a/listener_test.go
+++ b/listener_test.go
@@ -71,9 +71,41 @@ var _ = Describe("listener", func() {
 							{
 								"id":              &common.ColumnVal{Value: "i"},
 								"apid_cluster_id": &common.ColumnVal{Value: "a"},
-								"scope":           &common.ColumnVal{Value: "s"},
+								"scope":           &common.ColumnVal{Value: "s1"},
 								"org":             &common.ColumnVal{Value: "o"},
-								"env":             &common.ColumnVal{Value: "e"},
+								"env":             &common.ColumnVal{Value: "e1"},
+								"created":         &common.ColumnVal{Value: "c"},
+								"created_by":      &common.ColumnVal{Value: "c"},
+								"updated":         &common.ColumnVal{Value: "u"},
+								"updated_by":      &common.ColumnVal{Value: "u"},
+							},
+						},
+					},
+					{
+						Name: LISTENER_TABLE_DATA_SCOPE,
+						Rows: []common.Row{
+							{
+								"id":              &common.ColumnVal{Value: "j"},
+								"apid_cluster_id": &common.ColumnVal{Value: "a"},
+								"scope":           &common.ColumnVal{Value: "s1"},
+								"org":             &common.ColumnVal{Value: "o"},
+								"env":             &common.ColumnVal{Value: "e2"},
+								"created":         &common.ColumnVal{Value: "c"},
+								"created_by":      &common.ColumnVal{Value: "c"},
+								"updated":         &common.ColumnVal{Value: "u"},
+								"updated_by":      &common.ColumnVal{Value: "u"},
+							},
+						},
+					},
+					{
+						Name: LISTENER_TABLE_DATA_SCOPE,
+						Rows: []common.Row{
+							{
+								"id":              &common.ColumnVal{Value: "k"},
+								"apid_cluster_id": &common.ColumnVal{Value: "a"},
+								"scope":           &common.ColumnVal{Value: "s2"},
+								"org":             &common.ColumnVal{Value: "o"},
+								"env":             &common.ColumnVal{Value: "e3"},
 								"created":         &common.ColumnVal{Value: "c"},
 								"created_by":      &common.ColumnVal{Value: "c"},
 								"updated":         &common.ColumnVal{Value: "u"},
@@ -141,17 +173,29 @@ var _ = Describe("listener", func() {
 				dds = append(dds, d)
 			}
 
-			Expect(len(dds)).To(Equal(1))
+			Expect(len(dds)).To(Equal(3))
 			ds := dds[0]
 
 			Expect(ds.ID).To(Equal("i"))
 			Expect(ds.Org).To(Equal("o"))
-			Expect(ds.Env).To(Equal("e"))
-			Expect(ds.Scope).To(Equal("s"))
+			Expect(ds.Env).To(Equal("e1"))
+			Expect(ds.Scope).To(Equal("s1"))
 			Expect(ds.Created).To(Equal("c"))
 			Expect(ds.CreatedBy).To(Equal("c"))
 			Expect(ds.Updated).To(Equal("u"))
 			Expect(ds.UpdatedBy).To(Equal("u"))
+
+			ds = dds[1]
+			Expect(ds.Env).To(Equal("e2"))
+			Expect(ds.Scope).To(Equal("s1"))
+			ds = dds[2]
+			Expect(ds.Env).To(Equal("e3"))
+			Expect(ds.Scope).To(Equal("s2"))
+
+			scopes := findScopesForId("a")
+			Expect(len(scopes)).To(Equal(2))
+			Expect(scopes[0]).To(Equal("s1"))
+			Expect(scopes[1]).To(Equal("s2"))
 		})
 	})
 
@@ -204,7 +248,22 @@ var _ = Describe("listener", func() {
 							NewRow: common.Row{
 								"id":              &common.ColumnVal{Value: "i"},
 								"apid_cluster_id": &common.ColumnVal{Value: "a"},
-								"scope":           &common.ColumnVal{Value: "s"},
+								"scope":           &common.ColumnVal{Value: "s1"},
+								"org":             &common.ColumnVal{Value: "o"},
+								"env":             &common.ColumnVal{Value: "e"},
+								"created":         &common.ColumnVal{Value: "c"},
+								"created_by":      &common.ColumnVal{Value: "c"},
+								"updated":         &common.ColumnVal{Value: "u"},
+								"updated_by":      &common.ColumnVal{Value: "u"},
+							},
+						},
+						{
+							Operation: common.Insert,
+							Table:     LISTENER_TABLE_DATA_SCOPE,
+							NewRow: common.Row{
+								"id":              &common.ColumnVal{Value: "j"},
+								"apid_cluster_id": &common.ColumnVal{Value: "a"},
+								"scope":           &common.ColumnVal{Value: "s2"},
 								"org":             &common.ColumnVal{Value: "o"},
 								"env":             &common.ColumnVal{Value: "e"},
 								"created":         &common.ColumnVal{Value: "c"},
@@ -236,17 +295,25 @@ var _ = Describe("listener", func() {
 					dds = append(dds, d)
 				}
 
-				Expect(len(dds)).To(Equal(1))
+				Expect(len(dds)).To(Equal(2))
 				ds := dds[0]
 
 				Expect(ds.ID).To(Equal("i"))
 				Expect(ds.Org).To(Equal("o"))
 				Expect(ds.Env).To(Equal("e"))
-				Expect(ds.Scope).To(Equal("s"))
+				Expect(ds.Scope).To(Equal("s1"))
 				Expect(ds.Created).To(Equal("c"))
 				Expect(ds.CreatedBy).To(Equal("c"))
 				Expect(ds.Updated).To(Equal("u"))
 				Expect(ds.UpdatedBy).To(Equal("u"))
+
+				ds = dds[1]
+				Expect(ds.Scope).To(Equal("s2"))
+
+				scopes := findScopesForId("a")
+				Expect(len(scopes)).To(Equal(2))
+				Expect(scopes[0]).To(Equal("s1"))
+				Expect(scopes[1]).To(Equal("s2"))
 			})
 
 			It("delete event should delete", func() {


### PR DESCRIPTION
The scopes are committed to the DB, either via a snapshot server or change server. The scopes are picked up from the DB for runtime use. 