### PR TITLE
Get a new snapshot, when there is change in scopes.

### DIFF
--- a/apigeeSync_suite_test.go
+++ b/apigeeSync_suite_test.go
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func(done Done) {
 	// Tests that entire bootstrap and set of sync operations work
 	var lastSnapshot *common.Snapshot
 
-	expectedSnapshotTables := make(map[string] bool)
+	expectedSnapshotTables := make(map[string]bool)
 	expectedSnapshotTables["kms.company"] = true
 	expectedSnapshotTables["edgex.apid_cluster"] = true
 	expectedSnapshotTables["edgex.data_scope"] = true
@@ -79,8 +79,8 @@ var _ = BeforeSuite(func(done Done) {
 			Expect(mapIsSubset(knownTables, expectedSnapshotTables)).To(BeTrue())
 
 			/* After this, we will mock changes for tables not present in the initial snapshot
- 			* until that is changed in the mock server, we have to spoof the known tables
-			*/
+			* until that is changed in the mock server, we have to spoof the known tables
+			 */
 
 			//add apid_cluster and data_scope since those would present if this were a real scenario
 			knownTables["kms.app_credential"] = true
@@ -89,7 +89,6 @@ var _ = BeforeSuite(func(done Done) {
 			knownTables["kms.company_developer"] = true
 			knownTables["kms.api_product"] = true
 			knownTables["kms.app"] = true
-
 
 			lastSnapshot = s
 

--- a/apigee_sync.go
+++ b/apigee_sync.go
@@ -167,7 +167,7 @@ func pollChangeAgent() error {
 		 */
 		if lastSequence != "" &&
 			getChangeStatus(lastSequence, resp.LastSequence) != 1 {
-			log.Errorf("Ignore change, already have newer changes")
+			log.Debugf("Ignore change, already have newer changes")
 			continue
 		}
 
@@ -193,8 +193,20 @@ func pollChangeAgent() error {
 		} else {
 			log.Debugf("No Changes detected for Scopes: %s", scopes)
 		}
-
 		updateSequence(resp.LastSequence)
+
+		/*
+		 * Check to see if there was any change in scope, if found handle it
+		 * by getting a new snapshot
+		 */
+		newScopes := findScopesForId(apidInfo.ClusterID)
+		if !ArrayEquals(newScopes, scopes) {
+			log.Debugf("Detected scope changes, going to fetch a new snapshot to sync...")
+			return changeServerError{
+				Code: "Scope changes detected; must get new snapshot",
+			}
+		}
+
 	}
 }
 
@@ -515,5 +527,20 @@ func mapIsSubset(a map[string]bool, b map[string]bool) bool {
 		}
 	}
 
+	return true
+}
+
+/*
+ * Returns true if the two arrays have matching contents
+ */
+func ArrayEquals(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
 	return true
 }

--- a/listener_test.go
+++ b/listener_test.go
@@ -328,6 +328,29 @@ var _ = Describe("listener", func() {
 				Expect(len(scopes)).To(Equal(2))
 				Expect(scopes[0]).To(Equal("s1"))
 				Expect(scopes[1]).To(Equal("s2"))
+
+				/* Simulate a datascope change */
+				event = common.ChangeList{
+					LastSequence: "testnew",
+					Changes: []common.Change{
+						{
+							Operation: common.Insert,
+							Table:     LISTENER_TABLE_DATA_SCOPE,
+							NewRow: common.Row{
+								"id":              &common.ColumnVal{Value: "k"},
+								"apid_cluster_id": &common.ColumnVal{Value: "a"},
+								"scope":           &common.ColumnVal{Value: "s3"},
+								"org":             &common.ColumnVal{Value: "o2"},
+								"env":             &common.ColumnVal{Value: "e"},
+							},
+						},
+					},
+				}
+				handler.Handle(&event)
+				newScopes := findScopesForId("a")
+				Expect(len(newScopes)).To(Equal(3))
+				Expect(ArrayEquals(newScopes, scopes)).To(Equal(false))
+
 			})
 
 			It("delete event should delete", func() {


### PR DESCRIPTION
The CI tests will cover the end to end tests, which will test for data validity after data scope updates. TBD (mock server to handle multiple scopes as well), so complex scenarios can be unit tested.