### PR TITLE
add graceful close() to snapshot downloading manager

### DIFF
--- a/apigee_sync.go
+++ b/apigee_sync.go
@@ -93,7 +93,7 @@ func Redirect(req *http.Request, _ []*http.Request) error {
 }
 
 func addHeaders(req *http.Request) {
-	req.Header.Add("Authorization", "Bearer "+ tokenManager.getBearerToken())
+	req.Header.Add("Authorization", "Bearer "+tokenManager.getBearerToken())
 	req.Header.Set("apid_instance_id", apidInfo.InstanceID)
 	req.Header.Set("apid_cluster_Id", apidInfo.ClusterID)
 	req.Header.Set("updated_at_apid", time.Now().Format(time.RFC3339))

--- a/apigee_sync.go
+++ b/apigee_sync.go
@@ -93,7 +93,7 @@ func Redirect(req *http.Request, _ []*http.Request) error {
 }
 
 func addHeaders(req *http.Request) {
-	req.Header.Add("Authorization", "Bearer "+tokenManager.getBearerToken())
+	req.Header.Set("Authorization", "Bearer "+tokenManager.getBearerToken())
 	req.Header.Set("apid_instance_id", apidInfo.InstanceID)
 	req.Header.Set("apid_cluster_Id", apidInfo.ClusterID)
 	req.Header.Set("updated_at_apid", time.Now().Format(time.RFC3339))

--- a/apigee_sync.go
+++ b/apigee_sync.go
@@ -33,8 +33,8 @@ func bootstrap() {
 		return
 	}
 
-	downloadBootSnapshot(nil)
-	downloadDataSnapshot(quitPollingSnapshotServer)
+	snapManager.downloadBootSnapshot()
+	snapManager.downloadDataSnapshot()
 
 	changeManager.pollChangeWithBackoff()
 

--- a/apigee_sync_test.go
+++ b/apigee_sync_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Sync", func() {
 			}
 			pie.Plugins = append(pie.Plugins, pluginData)
 			postInitPlugins(pie)
-		}, 3)
+		}, 5)
 
 		It("should bootstrap from local DB if present", func(done Done) {
 

--- a/apigee_sync_test.go
+++ b/apigee_sync_test.go
@@ -254,7 +254,6 @@ var _ = Describe("Sync", func() {
 			testMock.forceNewSnapshot()
 		})
 
-
 		It("Verify the Sequence Number Logic works as expected", func() {
 			Expect(getChangeStatus("1.1.1", "1.1.2")).To(Equal(1))
 			Expect(getChangeStatus("1.1.1", "1.2.1")).To(Equal(1))
@@ -271,14 +270,17 @@ var _ = Describe("Sync", func() {
 			initializeContext()
 
 			tokenManager = createTokenManager()
+			snapManager = createSnapShotManager()
 			events.Listen(ApigeeSyncEventSelector, &handler{})
 
 			scopes := []string{apidInfo.ClusterID}
 			snapshot := &common.Snapshot{}
-			downloadSnapshot(scopes, snapshot, nil)
-			storeBootSnapshot(snapshot)
-			storeDataSnapshot(snapshot)
+			snapManager.downloadSnapshot(scopes, snapshot)
+			snapManager.storeBootSnapshot(snapshot)
+			snapManager.storeDataSnapshot(snapshot)
 			restoreContext()
+			<-snapManager.close()
+			tokenManager.close()
 		}, 3)
 	})
 })

--- a/backoff.go
+++ b/backoff.go
@@ -2,8 +2,8 @@ package apidApigeeSync
 
 import (
 	"math"
-	"time"
 	"math/rand"
+	"time"
 )
 
 const defaultInitial time.Duration = 200 * time.Millisecond
@@ -13,7 +13,7 @@ const defaultFactor float64 = 2
 type Backoff struct {
 	attempt         int
 	initial, max    time.Duration
-	jitter bool
+	jitter          bool
 	backoffStrategy func() time.Duration
 }
 

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -24,7 +24,7 @@ var _ = Describe("backoff", func() {
 		})
 
 		It("should properly apply exponential backoff strategy", func() {
-			b := NewExponentialBackoff(200 * time.Millisecond, 2 * time.Second, 2, false)
+			b := NewExponentialBackoff(200*time.Millisecond, 2*time.Second, 2, false)
 			Expect(200 * time.Millisecond).To(Equal(b.Duration()))
 			Expect(1).To(Equal(b.Attempt()))
 			Expect(400 * time.Millisecond).To(Equal(b.Duration()))
@@ -36,7 +36,7 @@ var _ = Describe("backoff", func() {
 		})
 
 		It("should reset properly", func() {
-			b := NewExponentialBackoff(200 * time.Millisecond, 2 * time.Second, 2, false)
+			b := NewExponentialBackoff(200*time.Millisecond, 2*time.Second, 2, false)
 			Expect(200 * time.Millisecond).To(Equal(b.Duration()))
 			Expect(1).To(Equal(b.Attempt()))
 			Expect(400 * time.Millisecond).To(Equal(b.Duration()))

--- a/changes.go
+++ b/changes.go
@@ -44,20 +44,21 @@ func (c *pollChangeManager) close() <-chan bool {
 	if atomic.SwapInt32(c.isClosed, 1) == int32(1) {
 		log.Error("pollChangeManager: close() called on a closed pollChangeManager!")
 		go func() {
-			finishChan <- false
 			log.Debug("change manager closed")
+			finishChan <- false
 		}()
 		return finishChan
 	}
 	// not launched
 	if atomic.LoadInt32(c.isLaunched) == int32(0) {
-		log.Error("pollChangeManager: close() called when pollChangeWithBackoff unlaunched! Will wait until pollChangeWithBackoff is launched and then kill it and tokenManager!")
+		log.Debug("pollChangeManager: close() called when pollChangeWithBackoff unlaunched! Will wait until pollChangeWithBackoff is launched and then kill it and tokenManager!")
+		log.Warn("Attempt to close unstarted change manager")
 		go func() {
 			c.quitChan <- true
 			tokenManager.close()
 			<-snapManager.close()
-			finishChan <- false
 			log.Debug("change manager closed")
+			finishChan <- false
 		}()
 		return finishChan
 	}
@@ -67,8 +68,8 @@ func (c *pollChangeManager) close() <-chan bool {
 		c.quitChan <- true
 		tokenManager.close()
 		<-snapManager.close()
-		finishChan <- true
 		log.Debug("change manager closed")
+		finishChan <- true
 	}()
 	return finishChan
 }

--- a/changes.go
+++ b/changes.go
@@ -54,6 +54,7 @@ func (c *pollChangeManager) close() <-chan bool {
 		log.Error("pollChangeManager: close() called when pollChangeWithBackoff unlaunched! close tokenManager!")
 		go func() {
 			tokenManager.close()
+			<-snapManager.close()
 			finishChan <- false
 			log.Debug("change manager closed")
 		}()
@@ -64,6 +65,7 @@ func (c *pollChangeManager) close() <-chan bool {
 	go func() {
 		c.quitChan <- true
 		tokenManager.close()
+		<-snapManager.close()
 		finishChan <- true
 		log.Debug("change manager closed")
 	}()
@@ -260,7 +262,7 @@ func (c *pollChangeManager) handleChangeServerError(err error) {
 	}
 	if _, ok := err.(changeServerError); ok {
 		log.Info("Detected DDL changes, going to fetch a new snapshot to sync...")
-		downloadDataSnapshot(c.quitChan)
+		snapManager.downloadDataSnapshot()
 	} else {
 		log.Debugf("Error connecting to changeserver: %v", err)
 	}

--- a/init.go
+++ b/init.go
@@ -30,15 +30,15 @@ const (
 
 var (
 	/* All set during plugin initialization */
-	log                       apid.LogService
-	config                    apid.ConfigService
-	dataService               apid.DataService
-	events                    apid.EventsService
-	apidInfo                  apidInstanceInfo
-	newInstanceID             bool
-	tokenManager              *tokenMan
-	changeManager             *pollChangeManager
-	quitPollingSnapshotServer chan bool
+	log           apid.LogService
+	config        apid.ConfigService
+	dataService   apid.DataService
+	events        apid.EventsService
+	apidInfo      apidInstanceInfo
+	newInstanceID bool
+	tokenManager  *tokenMan
+	changeManager *pollChangeManager
+	snapManager   *snapShotManager
 
 	/* Set during post plugin initialization
 	 * set this as a default, so that it's guaranteed to be valid even if postInitPlugins isn't called
@@ -76,7 +76,7 @@ func initVariables(services apid.Services) error {
 	events = services.Events()
 	//TODO listen for arbitrary commands, these channels can be used to kill polling goroutines
 	//also useful for testing
-	quitPollingSnapshotServer = make(chan bool)
+	snapManager = createSnapShotManager()
 	changeManager = createChangeManager()
 
 	// set up default database

--- a/snapshot.go
+++ b/snapshot.go
@@ -67,7 +67,6 @@ func (s *snapShotManager) close() <-chan bool {
 func (s *snapShotManager) downloadBootSnapshot() {
 	if atomic.SwapInt32(s.isDownloading, 1) == int32(1) {
 		log.Panic("downloadBootSnapshot: only 1 thread can download snapshot at the same time!")
-		return
 	}
 	defer atomic.StoreInt32(s.isDownloading, int32(0))
 
@@ -81,7 +80,7 @@ func (s *snapShotManager) downloadBootSnapshot() {
 
 	scopes := []string{apidInfo.ClusterID}
 	snapshot := &common.Snapshot{}
-  
+
 	err := s.downloadSnapshot(scopes, snapshot)
 	if err != nil {
 		// this may happen during shutdown
@@ -98,10 +97,10 @@ func (s *snapShotManager) downloadBootSnapshot() {
 	}
 
 	// note that for boot snapshot case, we don't need to inform plugins as they'll get the data snapshot
-  storeBootSnapshot(snapshot)
+	s.storeBootSnapshot(snapshot)
 }
 
-func storeBootSnapshot(snapshot *common.Snapshot) {
+func (s *snapShotManager) storeBootSnapshot(snapshot *common.Snapshot) {
 	processSnapshot(snapshot)
 }
 
@@ -109,7 +108,6 @@ func storeBootSnapshot(snapshot *common.Snapshot) {
 func (s *snapShotManager) downloadDataSnapshot() {
 	if atomic.SwapInt32(s.isDownloading, 1) == int32(1) {
 		log.Panic("downloadDataSnapshot: only 1 thread can download snapshot at the same time!")
-		return
 	}
 	defer atomic.StoreInt32(s.isDownloading, int32(0))
 
@@ -132,10 +130,10 @@ func (s *snapShotManager) downloadDataSnapshot() {
 		}
 		return
 	}
-	storeDataSnapshot(snapshot)
+	s.storeDataSnapshot(snapshot)
 }
 
-func storeDataSnapshot(snapshot *common.Snapshot) {
+func (s *snapShotManager) storeDataSnapshot(snapshot *common.Snapshot) {
 	knownTables = extractTablesFromSnapshot(snapshot)
 
 	db, err := dataService.DBVersion(snapshot.SnapshotInfo)


### PR DESCRIPTION
No race now.
Just  `go test -race`, just come to me if you see any race.

made a snapshot downloading manager to manage snapshot downloading
added graceful close() to snapshot downloading manager, which is called by the close() of pollChangeManager.
fixed a problem in change polling server
graceful shutdown of tokenManager and pollChangeManager have been merged into master during refactor.