### PR TITLE
Have a single client connection and reuse

### DIFF
--- a/apigee_sync.go
+++ b/apigee_sync.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	httpTimeout   = time.Minute
-	pluginTimeout = time.Minute
+	httpTimeout         = time.Minute
+	pluginTimeout       = time.Minute
+	maxIdleConnsPerHost = 10
 )
 
 var knownTables = make(map[string]bool)

--- a/apigee_sync_test.go
+++ b/apigee_sync_test.go
@@ -292,12 +292,12 @@ var _ = Describe("Sync", func() {
 			}))
 			tr := &http.Transport{
 				DisableKeepAlives:   true,
-				MaxIdleConnsPerHost: 10,
+				MaxIdleConnsPerHost: maxIdleConnsPerHost,
 			}
 			var rspcnt int = 0
 			ch := make(chan *http.Response)
 			client := &http.Client{Transport: tr}
-			for i := 0; i < maxIdleConnsPerHost; i++ {
+			for i := 0; i < 2*maxIdleConnsPerHost; i++ {
 				go func(client *http.Client) {
 					req, err := http.NewRequest("GET", server.URL, nil)
 					resp, err := client.Do(req)
@@ -313,7 +313,7 @@ var _ = Describe("Sync", func() {
 				select {
 				case resp := <-ch:
 					Expect(resp.StatusCode).To(Equal(http.StatusOK))
-					if rspcnt >= maxIdleConnsPerHost-1 {
+					if rspcnt >= 2*maxIdleConnsPerHost-1 {
 						return
 					}
 					rspcnt++

--- a/apigee_sync_test.go
+++ b/apigee_sync_test.go
@@ -268,12 +268,8 @@ var _ = Describe("Sync", func() {
 		 */
 		It("Should be able to handle duplicate snapshot during bootstrap", func() {
 			initializeContext()
-			tr := &http.Transport{
-				MaxIdleConnsPerHost: maxIdleConnsPerHost,
-			}
-			client := &http.Client{Transport: tr, Timeout: httpTimeout}
 			tokenManager = createTokenManager()
-			snapManager = createSnapShotManager(client)
+			snapManager = createSnapShotManager()
 			events.Listen(ApigeeSyncEventSelector, &handler{})
 
 			scopes := []string{apidInfo.ClusterID}

--- a/apigee_sync_test.go
+++ b/apigee_sync_test.go
@@ -269,7 +269,6 @@ var _ = Describe("Sync", func() {
 		It("Should be able to handle duplicate snapshot during bootstrap", func() {
 			initializeContext()
 			tr := &http.Transport{
-				DisableKeepAlives:   true,
 				MaxIdleConnsPerHost: maxIdleConnsPerHost,
 			}
 			client := &http.Client{Transport: tr, Timeout: httpTimeout}
@@ -291,7 +290,6 @@ var _ = Describe("Sync", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			}))
 			tr := &http.Transport{
-				DisableKeepAlives:   true,
 				MaxIdleConnsPerHost: maxIdleConnsPerHost,
 			}
 			var rspcnt int = 0

--- a/changes.go
+++ b/changes.go
@@ -21,18 +21,15 @@ type pollChangeManager struct {
 	// 0 for pollChangeWithBackoff() not launched, 1 for launched
 	isLaunched *int32
 	quitChan   chan bool
-	client     *http.Client
 }
 
-func createChangeManager(client *http.Client) *pollChangeManager {
+func createChangeManager() *pollChangeManager {
 	isClosedInt := int32(0)
 	isLaunchedInt := int32(0)
-	client.CheckRedirect = nil
 	return &pollChangeManager{
 		isClosed:   &isClosedInt,
 		quitChan:   make(chan bool),
 		isLaunched: &isLaunchedInt,
-		client:     client,
 	}
 }
 
@@ -166,8 +163,8 @@ func (c *pollChangeManager) getChanges(changesUri *url.URL) error {
 	/* If error, break the loop, and retry after interval */
 	req, err := http.NewRequest("GET", uri, nil)
 	addHeaders(req)
-
-	r, err := c.client.Do(req)
+	httpclient.CheckRedirect = nil
+	r, err := httpclient.Do(req)
 	if err != nil {
 		log.Errorf("change agent comm error: %s", err)
 		// if closed

--- a/changes.go
+++ b/changes.go
@@ -162,7 +162,6 @@ func (c *pollChangeManager) getChanges(changesUri *url.URL) error {
 	/* If error, break the loop, and retry after interval */
 	req, err := http.NewRequest("GET", uri, nil)
 	addHeaders(req)
-	httpclient.CheckRedirect = nil
 	r, err := httpclient.Do(req)
 	if err != nil {
 		log.Errorf("change agent comm error: %s", err)

--- a/init.go
+++ b/init.go
@@ -3,8 +3,8 @@ package apidApigeeSync
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
-
 	"time"
 
 	"github.com/30x/apid-core"
@@ -74,10 +74,17 @@ func initConfigDefaults() {
 func initVariables(services apid.Services) error {
 	dataService = services.Data()
 	events = services.Events()
+
+	tr := &http.Transport{
+		DisableKeepAlives:   false,
+		MaxIdleConnsPerHost: maxIdleConnsPerHost,
+	}
+	client := &http.Client{Transport: tr, Timeout: httpTimeout}
+
 	//TODO listen for arbitrary commands, these channels can be used to kill polling goroutines
 	//also useful for testing
-	snapManager = createSnapShotManager()
-	changeManager = createChangeManager()
+	snapManager = createSnapShotManager(client)
+	changeManager = createChangeManager(client)
 
 	// set up default database
 	db, err := dataService.DB()

--- a/init.go
+++ b/init.go
@@ -79,7 +79,14 @@ func initVariables(services apid.Services) error {
 	tr := &http.Transport{
 		MaxIdleConnsPerHost: maxIdleConnsPerHost,
 	}
-	httpclient = &http.Client{Transport: tr, Timeout: httpTimeout}
+	httpclient = &http.Client{
+		Transport: tr,
+		Timeout:   httpTimeout,
+		CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+			req.Header.Set("Authorization", "Bearer "+tokenManager.getBearerToken())
+			return nil
+		},
+	}
 
 	//TODO listen for arbitrary commands, these channels can be used to kill polling goroutines
 	//also useful for testing

--- a/init.go
+++ b/init.go
@@ -76,7 +76,6 @@ func initVariables(services apid.Services) error {
 	events = services.Events()
 
 	tr := &http.Transport{
-		DisableKeepAlives:   false,
 		MaxIdleConnsPerHost: maxIdleConnsPerHost,
 	}
 	client := &http.Client{Transport: tr, Timeout: httpTimeout}

--- a/init.go
+++ b/init.go
@@ -39,6 +39,7 @@ var (
 	tokenManager  *tokenMan
 	changeManager *pollChangeManager
 	snapManager   *snapShotManager
+	httpclient    *http.Client
 
 	/* Set during post plugin initialization
 	 * set this as a default, so that it's guaranteed to be valid even if postInitPlugins isn't called
@@ -78,12 +79,12 @@ func initVariables(services apid.Services) error {
 	tr := &http.Transport{
 		MaxIdleConnsPerHost: maxIdleConnsPerHost,
 	}
-	client := &http.Client{Transport: tr, Timeout: httpTimeout}
+	httpclient = &http.Client{Transport: tr, Timeout: httpTimeout}
 
 	//TODO listen for arbitrary commands, these channels can be used to kill polling goroutines
 	//also useful for testing
-	snapManager = createSnapShotManager(client)
-	changeManager = createChangeManager(client)
+	snapManager = createSnapShotManager()
+	changeManager = createChangeManager()
 
 	// set up default database
 	db, err := dataService.DB()

--- a/snapshot.go
+++ b/snapshot.go
@@ -247,11 +247,6 @@ func (s *snapShotManager) downloadSnapshot(scopes []string, snapshot *common.Sna
 	uri := snapshotUri.String()
 	log.Infof("Snapshot Download: %s", uri)
 
-	httpclient.CheckRedirect = func(req *http.Request, _ []*http.Request) error {
-		req.Header.Set("Authorization", "Bearer "+tokenManager.getBearerToken())
-		return nil
-
-	}
 	//pollWithBackoff only accepts function that accept a single quit channel
 	//to accommodate functions which need more parameters, wrap them in closures
 	attemptDownload := getAttemptDownloadClosure(httpclient, snapshot, uri)

--- a/snapshot.go
+++ b/snapshot.go
@@ -249,12 +249,12 @@ func (s *snapShotManager) downloadSnapshot(scopes []string, snapshot *common.Sna
 
 	//pollWithBackoff only accepts function that accept a single quit channel
 	//to accommodate functions which need more parameters, wrap them in closures
-	attemptDownload := getAttemptDownloadClosure(httpclient, snapshot, uri)
+	attemptDownload := getAttemptDownloadClosure(snapshot, uri)
 	pollWithBackoff(s.quitChan, attemptDownload, handleSnapshotServerError)
 	return nil
 }
 
-func getAttemptDownloadClosure(client *http.Client, snapshot *common.Snapshot, uri string) func(chan bool) error {
+func getAttemptDownloadClosure(snapshot *common.Snapshot, uri string) func(chan bool) error {
 	return func(_ chan bool) error {
 		req, err := http.NewRequest("GET", uri, nil)
 		if err != nil {
@@ -275,7 +275,7 @@ func getAttemptDownloadClosure(client *http.Client, snapshot *common.Snapshot, u
 		}
 
 		// Issue the request to the snapshot server
-		r, err := client.Do(req)
+		r, err := httpclient.Do(req)
 		if err != nil {
 			log.Errorf("Snapshotserver comm error: %v", err)
 			return err


### PR DESCRIPTION
Instead of having opening client connections each time, open client once and reuse it. Verified that no race exists and manual testing of apid to ensure it works the same as before.