### PR TITLE
Xapid 1020

### DIFF
--- a/apigee_sync.go
+++ b/apigee_sync.go
@@ -39,7 +39,7 @@ func bootstrap() {
 
 	if apidInfo.LastSnapshot != "" {
 		snapshot := startOnLocalSnapshot(apidInfo.LastSnapshot)
-
+		processSnapshot(snapshot)
 		events.EmitWithCallback(ApigeeSyncEventSelector, snapshot, func(event apid.Event) {
 			apidChangeManager.pollChangeWithBackoff()
 		})

--- a/apigee_sync_test.go
+++ b/apigee_sync_test.go
@@ -306,7 +306,7 @@ var _ = Describe("Sync", func() {
 			apidTokenManager = createSimpleTokenManager()
 			apidTokenManager.start()
 			apidSnapshotManager = createSnapShotManager()
-			events.Listen(ApigeeSyncEventSelector, &handler{})
+			//events.Listen(ApigeeSyncEventSelector, &handler{})
 
 			scopes := []string{apidInfo.ClusterID}
 			snapshot := &common.Snapshot{}

--- a/change_test.go
+++ b/change_test.go
@@ -80,6 +80,10 @@ var _ = Describe("Change Agent", func() {
 			config.Set(configPollInterval, 10*time.Millisecond)
 		}
 
+		AfterEach(func() {
+			restoreContext()
+		})
+
 		It("test change agent with authorization failure", func() {
 			log.Debug("test change agent with authorization failure")
 			testTokenManager := &dummyTokenManager{make(chan bool)}
@@ -94,7 +98,6 @@ var _ = Describe("Change Agent", func() {
 			<-testTokenManager.invalidateChan
 			log.Debug("closing")
 			<-apidChangeManager.close()
-			restoreContext()
 		})
 
 		It("test change agent with too old snapshot", func() {
@@ -113,7 +116,6 @@ var _ = Describe("Change Agent", func() {
 			<-testSnapshotManager.downloadCalledChan
 			log.Debug("closing")
 			<-apidChangeManager.close()
-			restoreContext()
 		})
 
 		It("change agent should retry with authorization failure", func(done Done) {
@@ -135,7 +137,6 @@ var _ = Describe("Change Agent", func() {
 					go func() {
 						// when close done, all handlers for the first snapshot have been executed
 						<-closeDone
-						restoreContext()
 						close(done)
 					}()
 
@@ -145,7 +146,7 @@ var _ = Describe("Change Agent", func() {
 			apidChangeManager.pollChangeWithBackoff()
 			// auth check fails
 			<-testTokenManager.invalidateChan
-		})
+		}, 2)
 
 	})
 })

--- a/change_test.go
+++ b/change_test.go
@@ -27,7 +27,6 @@ import (
 var _ = Describe("Change Agent", func() {
 
 	Context("Change Agent Unit Tests", func() {
-		handler := handler{}
 
 		var createTestDb = func(sqlfile string, dbId string) common.Snapshot {
 			initDb(sqlfile, "./mockdb_change.sqlite3")
@@ -46,7 +45,7 @@ var _ = Describe("Change Agent", func() {
 
 		BeforeEach(func() {
 			event := createTestDb("./sql/init_mock_db.sql", "test_change")
-			handler.Handle(&event)
+			processSnapshot(&event)
 			knownTables = extractTablesFromDB(getDB())
 		})
 

--- a/changes.go
+++ b/changes.go
@@ -252,6 +252,7 @@ func (c *pollChangeManager) getChanges(changesUri *url.URL) error {
 
 	/* If valid data present, Emit to plugins */
 	if len(resp.Changes) > 0 {
+		processChangeList(&resp)
 		select {
 		case <-time.After(httpTimeout):
 			log.Panic("Timeout. Plugins failed to respond to changes.")

--- a/changes.go
+++ b/changes.go
@@ -98,8 +98,8 @@ func (c *pollChangeManager) pollChangeWithBackoff() {
 		return
 	}
 
-	go pollWithBackoff(c.quitChan, c.pollChangeAgent, c.handleChangeServerError)
 	log.Debug("pollChangeManager: pollChangeWithBackoff() started pollWithBackoff")
+	go pollWithBackoff(c.quitChan, c.pollChangeAgent, c.handleChangeServerError)
 
 }
 

--- a/init.go
+++ b/init.go
@@ -228,7 +228,6 @@ func postInitPlugins(event apid.Event) {
 		apidTokenManager.start()
 		go bootstrap()
 
-		events.Listen(ApigeeSyncEventSelector, &handler{})
 		log.Debug("Done post plugin init")
 	}
 }

--- a/listener.go
+++ b/listener.go
@@ -24,24 +24,6 @@ const (
 	LISTENER_TABLE_DATA_SCOPE   = "edgex.data_scope"
 )
 
-type handler struct {
-}
-
-func (h *handler) String() string {
-	return "ApigeeSync"
-}
-
-func (h *handler) Handle(e apid.Event) {
-
-	if changeSet, ok := e.(*common.ChangeList); ok {
-		processChangeList(changeSet)
-	} else if snapShot, ok := e.(*common.Snapshot); ok {
-		processSnapshot(snapShot)
-	} else {
-		log.Debugf("Received invalid event. Ignoring. %v", e)
-	}
-}
-
 func processSnapshot(snapshot *common.Snapshot) {
 	log.Debugf("Snapshot received. Switching to DB version: %s", snapshot.SnapshotInfo)
 

--- a/listener_test.go
+++ b/listener_test.go
@@ -24,7 +24,7 @@ import (
 
 var _ = Describe("listener", func() {
 
-	handler := handler{}
+
 
 	var createTestDb = func(sqlfile string, dbId string) common.Snapshot {
 		initDb(sqlfile, "./mockdb.sqlite3")
@@ -41,7 +41,7 @@ var _ = Describe("listener", func() {
 
 		It("should fail if more than one apid_cluster rows", func() {
 			event := createTestDb("./sql/init_listener_test_duplicate_apids.sql", "test_snapshot_fail_multiple_clusters")
-			Expect(func() { handler.Handle(&event) }).To(Panic())
+			Expect(func() { processSnapshot(&event) }).To(Panic())
 		}, 3)
 
 		It("should fail if more than one apid_cluster rows", func() {
@@ -64,7 +64,7 @@ var _ = Describe("listener", func() {
 
 			event := createTestDb("./sql/init_listener_test_valid_snapshot.sql", "test_snapshot_valid")
 
-			handler.Handle(&event)
+			processSnapshot(&event)
 
 			info, err := getApidInstanceInfo()
 			Expect(err).NotTo(HaveOccurred())
@@ -160,7 +160,7 @@ var _ = Describe("listener", func() {
 
 			It("insert event should panic", func() {
 				ssEvent := createTestDb("./sql/init_listener_test_valid_snapshot.sql", "test_changes_insert_panic")
-				handler.Handle(&ssEvent)
+				processSnapshot(&ssEvent)
 
 				//save the last snapshot, so we can restore it at the end of this context
 
@@ -174,12 +174,12 @@ var _ = Describe("listener", func() {
 					},
 				}
 
-				Expect(func() { handler.Handle(&csEvent) }).To(Panic())
+				Expect(func(){processChangeList(&csEvent)}).To(Panic())
 			}, 3)
 
 			It("update event should panic", func() {
 				ssEvent := createTestDb("./sql/init_listener_test_valid_snapshot.sql", "test_changes_update_panic")
-				handler.Handle(&ssEvent)
+				processSnapshot(&ssEvent)
 
 				event := common.ChangeList{
 					LastSequence: "test",
@@ -191,7 +191,7 @@ var _ = Describe("listener", func() {
 					},
 				}
 
-				Expect(func() { handler.Handle(&event) }).To(Panic())
+				Expect(func(){processChangeList(&event)}).To(Panic())
 				//restore the last snapshot
 			}, 3)
 
@@ -201,7 +201,7 @@ var _ = Describe("listener", func() {
 
 			It("insert event should add", func() {
 				ssEvent := createTestDb("./sql/init_listener_test_no_datascopes.sql", "test_changes_insert")
-				handler.Handle(&ssEvent)
+				processSnapshot(&ssEvent)
 
 				event := common.ChangeList{
 					LastSequence: "test",
@@ -241,7 +241,7 @@ var _ = Describe("listener", func() {
 					},
 				}
 
-				handler.Handle(&event)
+				processChangeList(&event)
 
 				var dds []dataDataScope
 
@@ -286,7 +286,7 @@ var _ = Describe("listener", func() {
 
 			It("delete event should delete", func() {
 				ssEvent := createTestDb("./sql/init_listener_test_no_datascopes.sql", "test_changes_delete")
-				handler.Handle(&ssEvent)
+				processSnapshot(&ssEvent)
 				insert := common.ChangeList{
 					LastSequence: "test",
 					Changes: []common.Change{
@@ -309,7 +309,7 @@ var _ = Describe("listener", func() {
 					},
 				}
 
-				handler.Handle(&insert)
+				processChangeList(&insert)
 
 				delete := common.ChangeList{
 					LastSequence: "test",
@@ -322,7 +322,7 @@ var _ = Describe("listener", func() {
 					},
 				}
 
-				handler.Handle(&delete)
+				processChangeList(&delete)
 
 				var nRows int
 				err := getDB().QueryRow("SELECT count(id) FROM EDGEX_DATA_SCOPE").Scan(&nRows)
@@ -333,7 +333,7 @@ var _ = Describe("listener", func() {
 
 			It("update event should panic for data scopes table", func() {
 				ssEvent := createTestDb("./sql/init_listener_test_valid_snapshot.sql", "test_update_panic")
-				handler.Handle(&ssEvent)
+				processSnapshot(&ssEvent)
 
 				event := common.ChangeList{
 					LastSequence: "test",
@@ -345,7 +345,7 @@ var _ = Describe("listener", func() {
 					},
 				}
 
-				Expect(func() { handler.Handle(&event) }).To(Panic())
+				Expect(func() { processChangeList(&event) }).To(Panic())
 				//restore the last snapshot
 			}, 3)
 

--- a/listener_test.go
+++ b/listener_test.go
@@ -24,8 +24,6 @@ import (
 
 var _ = Describe("listener", func() {
 
-
-
 	var createTestDb = func(sqlfile string, dbId string) common.Snapshot {
 		initDb(sqlfile, "./mockdb.sqlite3")
 		file, err := os.Open("./mockdb.sqlite3")
@@ -174,7 +172,7 @@ var _ = Describe("listener", func() {
 					},
 				}
 
-				Expect(func(){processChangeList(&csEvent)}).To(Panic())
+				Expect(func() { processChangeList(&csEvent) }).To(Panic())
 			}, 3)
 
 			It("update event should panic", func() {
@@ -191,7 +189,7 @@ var _ = Describe("listener", func() {
 					},
 				}
 
-				Expect(func(){processChangeList(&event)}).To(Panic())
+				Expect(func() { processChangeList(&event) }).To(Panic())
 				//restore the last snapshot
 			}, 3)
 

--- a/snapshot.go
+++ b/snapshot.go
@@ -154,6 +154,7 @@ func (s *simpleSnapShotManager) storeDataSnapshot(snapshot *common.Snapshot) {
 		log.Panicf("Database inaccessible: %v", err)
 	}
 
+	processSnapshot(snapshot)
 	log.Info("Emitting Snapshot to plugins")
 
 	select {


### PR DESCRIPTION
fixed Xapid 1020:
https://apigeesc.atlassian.net/browse/XAPID-1020

Apart from apidGatewayDeploy, this race can also happen between apidApigeeSync and other plugins.
I make apidApigeeSync process Snapshot/Changelist before emitting events. When plugins receive events, sqlite DB has been updated, so everything is synchronized.