### PR TITLE
Clear the previous  hashmap once new SS is downloaded.

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -26,10 +26,11 @@ const (
 
 func processSnapshot(snapshot *common.Snapshot) {
 
+	var prevDb string
 	if apidInfo.LastSnapshot != "" && apidInfo.LastSnapshot != snapshot.SnapshotInfo {
 		log.Debugf("Release snapshot for {%s}. Switching to version {%s}",
 			apidInfo.LastSnapshot , snapshot.SnapshotInfo)
-		dataService.ReleaseDB(apidInfo.LastSnapshot)
+		prevDb = apidInfo.LastSnapshot
 	} else {
 		log.Debugf("Process snapshot for version {%s}",
 			snapshot.SnapshotInfo)
@@ -51,6 +52,10 @@ func processSnapshot(snapshot *common.Snapshot) {
 	setDB(db)
 	log.Debugf("Snapshot processed: %s", snapshot.SnapshotInfo)
 
+	// Releases the DB, when the Connection reference count reaches 0.
+	if prevDb != "" {
+		dataService.ReleaseDB(prevDb)
+	}
 }
 
 func processSqliteSnapshot(db apid.DB) {

--- a/listener.go
+++ b/listener.go
@@ -25,8 +25,15 @@ const (
 )
 
 func processSnapshot(snapshot *common.Snapshot) {
-	log.Debugf("Snapshot received. Switching to DB version: %s", snapshot.SnapshotInfo)
 
+	if apidInfo.LastSnapshot != "" && apidInfo.LastSnapshot != snapshot.SnapshotInfo {
+		log.Debugf("Release snapshot for {%s}. Switching to version {%s}",
+			apidInfo.LastSnapshot , snapshot.SnapshotInfo)
+		dataService.ReleaseDB(apidInfo.LastSnapshot)
+	} else {
+		log.Debugf("Process snapshot for version {%s}",
+			snapshot.SnapshotInfo)
+	}
 	db, err := dataService.DBVersion(snapshot.SnapshotInfo)
 	if err != nil {
 		log.Panicf("Unable to access database: %v", err)


### PR DESCRIPTION
Clear the previous hashmap once new SS is downloaded, and about to be processed.